### PR TITLE
Custom copy and equality for JSONAPIResource

### DIFF
--- a/Classes/JSONAPIResource.m
+++ b/Classes/JSONAPIResource.m
@@ -295,4 +295,32 @@
     }
 }
 
+#pragma mark - NSObject -
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object) return YES;
+    if (![object isMemberOfClass:[self class]]) return NO;
+    
+    for (NSString *key in self.propertyKeys) {
+        id selfValue = [self valueForKey:key];
+        id objectValue = [object valueForKey:key];
+        
+        BOOL valuesEqual = ((selfValue == nil && objectValue == nil) || [selfValue isEqual:objectValue]);
+        if (!valuesEqual) return NO;
+    }
+    
+    return YES;
+}
+
+- (NSUInteger)hash {
+    NSUInteger value = 0;
+    
+    for (NSString *key in self.propertyKeys) {
+        value ^= [[self valueForKey:key] hash];
+    }
+    
+    return value;
+}
+
 @end

--- a/Classes/JSONAPIResource.m
+++ b/Classes/JSONAPIResource.m
@@ -219,6 +219,15 @@
 
     }
     
+    BOOL isEmptyDictionary = !self.__dictionary || self.__dictionary.count == 0;
+    
+    if (isEmptyDictionary) {
+        for (NSString *key in self.propertyKeys) {
+            id selfValue = [self valueForKey:key];
+            [copy setValue:selfValue forKey:key];
+        }
+    }
+    
     return copy;
 }
 


### PR DESCRIPTION
I added extra copyWithZone: logic for JSONAPIResource subclasses that's not initiated from JSONAPIResourceModeler. I also added extra logic on isEqual: and hash method for the class :)
